### PR TITLE
Add requirements.txt, update README.md with "pip install -r requirements"

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ The script requires Python 3 and the following packages need to be installed (e.
 Running the automated tests requires
 [pytest](https://pypi.org/project/pytest/).
 
+You can install the above packages using pip with the following command:
+
+`pip install -r requirements.txt`
+
 ## Usage as library
 
 freeplane2md can as well be used from other scripts by importing as a module and calling the function `convert_file`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+docopt==0.6.2
+iniconfig==2.0.0
+packaging==23.1
+pluggy==1.3.0
+pytest==7.4.2
+python-dateutil==2.8.2
+six==1.16.0
+validators==0.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,4 @@
-docopt==0.6.2
-iniconfig==2.0.0
-packaging==23.1
-pluggy==1.3.0
-pytest==7.4.2
-python-dateutil==2.8.2
-six==1.16.0
-validators==0.22.0
+docopt~=0.6
+pytest~=7.0
+python_dateutil~=2.0
+validators~=0.0


### PR DESCRIPTION
Providing a `requirements.txt` makes sure packages will have the same versions across all machines to avoid breakage due to dependency hell and also allows installing them with a `pip install -r requirements.txt` one-liner instead of having the user manually track down the packages or typing `pip install docopt validators python-dateutils pytest`.

I find it especially useful in sandboxed environments created with [virtualenv](https://realpython.com/python-virtual-environments-a-primer/). That way people can install packages locally to the project without polluting their system with global packages.