### PR TITLE
Apply correct indentation for multiline nodes

### DIFF
--- a/freeplane2md.py
+++ b/freeplane2md.py
@@ -352,13 +352,16 @@ def link_targets(tree):
 
 def indent_multiline_text(text, level):
     # TODO: Apply same indentation follow to HTML rich content too
-    if text is None or text == "":
+    if text is None or text == '':
         return text
 
     lines = text.splitlines()
     result = lines[0]
     for line in lines[1:]:
-        result += '\n' + indent*(level) + line
+        result += '\n'
+        # Avoid padding an empty line with unnecessary leading whitespace
+        if line != '':
+            result += indent*(level) + line
 
     return result
 

--- a/freeplane2md.py
+++ b/freeplane2md.py
@@ -355,15 +355,7 @@ def indent_multiline_text(text, level):
     if text is None or text == '':
         return text
 
-    lines = text.splitlines()
-    result = lines[0]
-    for line in lines[1:]:
-        result += '\n'
-        # Avoid padding an empty line with unnecessary leading whitespace
-        if line != '':
-            result += indent*(level) + line
-
-    return result
+    return ('\n' + indent*level).join(text.splitlines())
 
 
 if __name__ == '__main__':

--- a/freeplane2md.py
+++ b/freeplane2md.py
@@ -231,7 +231,7 @@ def process_node(node, level, headerlevel=1, todo=False):
         markers = indent*(level-headerlevel-1) + bullet 
         ending = ''
 
-    yield ( markers + icons_md + map_links(node) + add_custom_ids(node)
+    yield ( markers + icons_md + map_links(node, level-headerlevel) + add_custom_ids(node)
         + map_richcontent(node) + ending )
 
     for child in node.findall('node'):
@@ -253,7 +253,7 @@ def map_icons(node):
     return icons_md
 
 
-def map_links(node):
+def map_links(node, level):
     """Augment node text with link, if present"""
     text = node.attrib.get('TEXT')
     link_str = node.attrib.get('LINK', "")
@@ -266,6 +266,9 @@ def map_links(node):
             text = link_str
         else:
             text = ""
+
+    text = indent_multiline_text(text, level)
+
     if link_str:
         # Simplify to automatic links for URLs or e-mail addresses and Wiki-links for Markdown files
         if text == link_str or text == link_str.replace("mailto:", ""):
@@ -345,6 +348,19 @@ def link_targets(tree):
     """
     return {node.attrib.get('LINK') for node in tree.iter('node')
             if node.attrib.get('LINK')}
+
+
+def indent_multiline_text(text, level):
+    # TODO: Apply same indentation follow to HTML rich content too
+    if text is None or text == "":
+        return text
+
+    lines = text.splitlines()
+    result = lines[0]
+    for line in lines[1:]:
+        result += '\n' + indent*(level) + line
+
+    return result
 
 
 if __name__ == '__main__':

--- a/test/expected-freeplaneUserGuide-introduction.md
+++ b/test/expected-freeplaneUserGuide-introduction.md
@@ -99,7 +99,7 @@
       - Icon bar {#1865250955} [#1865250955](#1865250955)
       - Properties Panel {#303482588} [#303482588](#303482588)
     - Background
-context menu
+      context menu
 
 <p>
       Right-click in free place of background
@@ -107,7 +107,7 @@ context menu
 
       - Background Context Menu {#1485150857} [#1485150857](#1485150857)
         - Open/close
-Tool panel {#724121688} [#724121688](#724121688)
+          Tool panel {#724121688} [#724121688](#724121688)
     - Help > Key reference
 
 <p>

--- a/test/expected-multiline-indentation.md
+++ b/test/expected-multiline-indentation.md
@@ -3,11 +3,11 @@
 ## Header
 
 - Subnote 1
-
+  
   text
   - Subsubnote 1
-
+    
     text
   - Subsubnote 2
-
+    
     text

--- a/test/expected-multiline-indentation.md
+++ b/test/expected-multiline-indentation.md
@@ -1,0 +1,13 @@
+# Test nested indentation
+
+## Header
+
+- Subnote 1
+  
+  text
+  - Subsubnote 1
+    
+    text
+  - Subsubnote 2
+    
+    text

--- a/test/expected-multiline-indentation.md
+++ b/test/expected-multiline-indentation.md
@@ -1,13 +1,13 @@
-# Test nested indentation
+# Test multiline indentation
 
 ## Header
 
 - Subnote 1
-  
+
   text
   - Subsubnote 1
-    
+
     text
   - Subsubnote 2
-    
+
     text

--- a/test/freeplaneUserGuide-introduction.md
+++ b/test/freeplaneUserGuide-introduction.md
@@ -99,7 +99,7 @@
       - Icon bar {#1865250955} [#1865250955](#1865250955)
       - Properties Panel {#303482588} [#303482588](#303482588)
     - Background
-context menu
+      context menu
 
 <p>
       Right-click in free place of background
@@ -107,7 +107,7 @@ context menu
 
       - Background Context Menu {#1485150857} [#1485150857](#1485150857)
         - Open/close
-Tool panel {#724121688} [#724121688](#724121688)
+          Tool panel {#724121688} [#724121688](#724121688)
     - Help > Key reference
 
 <p>

--- a/test/test-multiline-indentation.md
+++ b/test/test-multiline-indentation.md
@@ -3,11 +3,11 @@
 ## Header
 
 - Subnote 1
-
+  
   text
   - Subsubnote 1
-
+    
     text
   - Subsubnote 2
-
+    
     text

--- a/test/test-multiline-indentation.md
+++ b/test/test-multiline-indentation.md
@@ -1,0 +1,13 @@
+# Test nested indentation
+
+## Header
+
+- Subnote 1
+  
+  text
+  - Subsubnote 1
+    
+    text
+  - Subsubnote 2
+    
+    text

--- a/test/test-multiline-indentation.md
+++ b/test/test-multiline-indentation.md
@@ -1,13 +1,13 @@
-# Test nested indentation
+# Test multiline indentation
 
 ## Header
 
 - Subnote 1
-  
+
   text
   - Subsubnote 1
-    
+
     text
   - Subsubnote 2
-    
+
     text

--- a/test/test-multiline-indentation.mm
+++ b/test/test-multiline-indentation.mm
@@ -1,0 +1,80 @@
+<map version="freeplane 1.11.5">
+<!--To view this file, download free mind mapping software Freeplane from https://www.freeplane.org -->
+<node TEXT="Test multiline indentation" FOLDED="false" ID="ID_696401721" CREATED="1610381621824" MODIFIED="1694545143957" STYLE="oval">
+<font SIZE="18"/>
+<hook NAME="MapStyle">
+    <properties edgeColorConfiguration="#808080ff,#ff0000ff,#0000ffff,#00ff00ff,#ff00ffff,#00ffffff,#7c0000ff,#00007cff,#007c00ff,#7c007cff,#007c7cff,#7c7c00ff" associatedTemplateLocation="template:/standard-1.6.mm" fit_to_viewport="false"/>
+
+<map_styles>
+<stylenode LOCALIZED_TEXT="styles.root_node" STYLE="oval" UNIFORM_SHAPE="true" VGAP_QUANTITY="24 pt">
+<font SIZE="24"/>
+<stylenode LOCALIZED_TEXT="styles.predefined" POSITION="bottom_or_right" STYLE="bubble">
+<stylenode LOCALIZED_TEXT="default" ID="ID_271890427" ICON_SIZE="12 pt" COLOR="#000000" STYLE="fork">
+<arrowlink SHAPE="CUBIC_CURVE" COLOR="#000000" WIDTH="2" TRANSPARENCY="200" DASH="" FONT_SIZE="9" FONT_FAMILY="SansSerif" DESTINATION="ID_271890427" STARTARROW="NONE" ENDARROW="DEFAULT"/>
+<font NAME="SansSerif" SIZE="10" BOLD="false" ITALIC="false"/>
+<richcontent TYPE="DETAILS" CONTENT-TYPE="plain/auto"/>
+<richcontent TYPE="NOTE" CONTENT-TYPE="plain/auto"/>
+</stylenode>
+<stylenode LOCALIZED_TEXT="defaultstyle.details"/>
+<stylenode LOCALIZED_TEXT="defaultstyle.attributes">
+<font SIZE="9"/>
+</stylenode>
+<stylenode LOCALIZED_TEXT="defaultstyle.note" COLOR="#000000" BACKGROUND_COLOR="#ffffff" TEXT_ALIGN="LEFT"/>
+<stylenode LOCALIZED_TEXT="defaultstyle.floating">
+<edge STYLE="hide_edge"/>
+<cloud COLOR="#f0f0f0" SHAPE="ROUND_RECT"/>
+</stylenode>
+<stylenode LOCALIZED_TEXT="defaultstyle.selection" BACKGROUND_COLOR="#afd3f7" BORDER_COLOR_LIKE_EDGE="false" BORDER_COLOR="#afd3f7"/>
+</stylenode>
+<stylenode LOCALIZED_TEXT="styles.user-defined" POSITION="bottom_or_right" STYLE="bubble">
+<stylenode LOCALIZED_TEXT="styles.topic" COLOR="#18898b" STYLE="fork">
+<font NAME="Liberation Sans" SIZE="10" BOLD="true"/>
+</stylenode>
+<stylenode LOCALIZED_TEXT="styles.subtopic" COLOR="#cc3300" STYLE="fork">
+<font NAME="Liberation Sans" SIZE="10" BOLD="true"/>
+</stylenode>
+<stylenode LOCALIZED_TEXT="styles.subsubtopic" COLOR="#669900">
+<font NAME="Liberation Sans" SIZE="10" BOLD="true"/>
+</stylenode>
+<stylenode LOCALIZED_TEXT="styles.important" ID="ID_67550811">
+<icon BUILTIN="yes"/>
+<arrowlink COLOR="#003399" TRANSPARENCY="255" DESTINATION="ID_67550811"/>
+</stylenode>
+</stylenode>
+<stylenode LOCALIZED_TEXT="styles.AutomaticLayout" POSITION="bottom_or_right" STYLE="bubble">
+<stylenode LOCALIZED_TEXT="AutomaticLayout.level.root" COLOR="#000000" STYLE="oval" SHAPE_HORIZONTAL_MARGIN="10 pt" SHAPE_VERTICAL_MARGIN="10 pt">
+<font SIZE="18"/>
+</stylenode>
+<stylenode LOCALIZED_TEXT="AutomaticLayout.level,1" COLOR="#0033ff">
+<font SIZE="16"/>
+</stylenode>
+<stylenode LOCALIZED_TEXT="AutomaticLayout.level,2" COLOR="#00b439">
+<font SIZE="14"/>
+</stylenode>
+<stylenode LOCALIZED_TEXT="AutomaticLayout.level,3" COLOR="#990000">
+<font SIZE="12"/>
+</stylenode>
+<stylenode LOCALIZED_TEXT="AutomaticLayout.level,4" COLOR="#111111">
+<font SIZE="10"/>
+</stylenode>
+<stylenode LOCALIZED_TEXT="AutomaticLayout.level,5"/>
+<stylenode LOCALIZED_TEXT="AutomaticLayout.level,6"/>
+<stylenode LOCALIZED_TEXT="AutomaticLayout.level,7"/>
+<stylenode LOCALIZED_TEXT="AutomaticLayout.level,8"/>
+<stylenode LOCALIZED_TEXT="AutomaticLayout.level,9"/>
+<stylenode LOCALIZED_TEXT="AutomaticLayout.level,10"/>
+<stylenode LOCALIZED_TEXT="AutomaticLayout.level,11"/>
+</stylenode>
+</stylenode>
+</map_styles>
+</hook>
+<hook NAME="AutomaticEdgeColor" COUNTER="2" RULE="ON_BRANCH_CREATION"/>
+<node TEXT="Header" POSITION="bottom_or_right" ID="ID_1510026736" CREATED="1694545146787" MODIFIED="1694546819339">
+<edge COLOR="#ff0000"/>
+<node TEXT="Subnote 1&#xa;&#xa;text" ID="ID_1496921501" CREATED="1694545163556" MODIFIED="1694545461104">
+<node TEXT="Subsubnote 1&#xa;&#xa;text" ID="ID_167579473" CREATED="1694545163556" MODIFIED="1694545474688"/>
+<node TEXT="Subsubnote 2&#xa;&#xa;text" ID="ID_160635297" CREATED="1694545163556" MODIFIED="1694545480949"/>
+</node>
+</node>
+</node>
+</map>

--- a/test_freeplane2md.py
+++ b/test_freeplane2md.py
@@ -66,7 +66,7 @@ def test_freeplaneUserGuide():
     with open('test/expected-freeplaneUserGuide-introduction.md') as expected, open('test/freeplaneUserGuide-introduction.md') as testee:
         assert(expected.readlines() == testee.readlines())
 
-def test_nested_indentation():
+def test_multiline_indentation():
     """Test that nodes with multiline text follow indentations in Markdown"""
     freeplane2md.convert_file('test/test-multiline-indentation.mm', 'test/test-multiline-indentation.md', headerlevel=2, no_timestamp=True)
     with open('test/expected-multiline-indentation.md') as expected, open('test/test-multiline-indentation.md') as testee:

--- a/test_freeplane2md.py
+++ b/test_freeplane2md.py
@@ -66,6 +66,12 @@ def test_freeplaneUserGuide():
     with open('test/expected-freeplaneUserGuide-introduction.md') as expected, open('test/freeplaneUserGuide-introduction.md') as testee:
         assert(expected.readlines() == testee.readlines())
 
+def test_nested_indentation():
+    """Test that nodes with multiline text follow indentations in Markdown"""
+    freeplane2md.convert_file('test/test-multiline-indentation.mm', 'test/test-multiline-indentation.md', headerlevel=2, no_timestamp=True)
+    with open('test/expected-multiline-indentation.md') as expected, open('test/test-multiline-indentation.md') as testee:
+        assert(expected.readlines() == testee.readlines())
+
 # ---
 
 def test_get_markdown_path():


### PR DESCRIPTION
There is a way for nodes that contain multiple lines to follow the indentation of the first line. The change also takes header level options into account too.

![mindmap](https://github.com/OliverCi/freeplane2md/assets/11887307/7e9cccdb-6228-48d6-bd1a-d01c966f2920)

Without the fix it would look like this:

```markdown
# Test multiline indentation

## Header

- Subnote 1

text
  - Subsubnote 1

text
  - Subsubnote 2

text

```

Using the fix, the lines will follow the indentation:

```markdown
# Test multiline indentation

## Header

- Subnote 1

  text
  - Subsubnote 1

    text
  - Subsubnote 2

    text
```

Providing the fix for HTML richcontent nodes is still a TODO though.